### PR TITLE
fix: correct version numbers in changelogs

### DIFF
--- a/zwave/Enbrighten-GE/ZW3107/14280 - Plug-in 2-Outlet Smart Dimmer, Simultaneous, 500S/14280_Revision_History.csv
+++ b/zwave/Enbrighten-GE/ZW3107/14280 - Plug-in 2-Outlet Smart Dimmer, Simultaneous, 500S/14280_Revision_History.csv
@@ -5,7 +5,7 @@ Product ID,0x3033,,
 VERSION,Z-Wave Devkit,Changes,Date Code
 5.07,6.51.06,1. Original Release Firmware,1544
 ,,OTA file will not be released for this version due to lack of support for Adesto flash in newer hardware,
-5.2,6.51.08,1. Updated the multilevel command class to version 2,1715
+5.20,6.51.08,1. Updated the multilevel command class to version 2,1715
 ,,2. Added parameter 6,
 ,,3. Fixed dimming behavior,
 ,,3. Modified the default setting for LED indication,

--- a/zwave/Enbrighten-GE/ZW4002/14287 - In-Wall Smart Fan Speed Control, 500S/14287_Revision_History.csv
+++ b/zwave/Enbrighten-GE/ZW4002/14287 - In-Wall Smart Fan Speed Control, 500S/14287_Revision_History.csv
@@ -3,7 +3,7 @@ Manufacturer ID,0x0063,,
 Product Type ID,0x4944,,
 Product ID,0x3131,,
 VERSION,Z-Wave Devkit,Changes,Date Code
-5.2,6.51.06,1. Original Release Firmware,1651
+5.20,6.51.06,1. Original Release Firmware,1651
 ,,OTA file will not be released for this version due to lack of support for Adesto flash in newer hardware,
 5.22,6.51.10,"1. Fixed the reset and exclusion failed status if the host is powered off and associated with G1, G2 and G3",1730
 ,,2. Fixed the manual reset failed status if the host is powered off and excluded,

--- a/zwave/Enbrighten-GE/ZW4002/55258 - In-Wall Smart Fan Speed Control, 500S/55258_Revision_History.csv
+++ b/zwave/Enbrighten-GE/ZW4002/55258 - In-Wall Smart Fan Speed Control, 500S/55258_Revision_History.csv
@@ -3,4 +3,4 @@ Manufacturer ID,0x0063,,
 Product Type ID,0x4944,,
 Product ID,0x3337,,
 VERSION,Z-Wave Devkit,Changes,Date Code
-5.5,6.82.00,1. Original Release Firmware,2036
+5.50,6.82.00,1. Original Release Firmware,2036

--- a/zwave/Enbrighten-GE/ZW4003/14292 - In-Wall Smart Toggle Switch, 500S/14292_Revision_History.csv
+++ b/zwave/Enbrighten-GE/ZW4003/14292 - In-Wall Smart Toggle Switch, 500S/14292_Revision_History.csv
@@ -3,7 +3,7 @@ Manufacturer ID,0x0063,,
 Product Type ID,0x4952,,
 Product ID,0x3037,,
 VERSION,Z-Wave Devkit,Changes,Date Code
-5.2,6.51.06,1. Original Release Firmware,1651
+5.20,6.51.06,1. Original Release Firmware,1651
 ,,OTA file will not be released for this version due to lack of support for Adesto flash in newer hardware,
 5.21,6.51.10,1. Updated the Devkit from 6.51.06 to 6.51.10,1742
 5.22,6.51.10,1. Added parameter 19 for alternate exclusion,1834

--- a/zwave/Enbrighten-GE/ZW4005/14291 - In-Wall Smart Paddle Switch, 500S/14291_Revision_History.csv
+++ b/zwave/Enbrighten-GE/ZW4005/14291 - In-Wall Smart Paddle Switch, 500S/14291_Revision_History.csv
@@ -3,7 +3,7 @@ Manufacturer ID,0x0063,,
 Product Type ID,0x4952,,
 Product ID,0x3036,,
 VERSION,Z-Wave Devkit,Changes,Date Code
-5.2,6.51.06,1. Original Release Firmware,1651
+5.20,6.51.06,1. Original Release Firmware,1651
 ,,OTA file will not be released for this version due to lack of support for Adesto flash in newer hardware,
 5.22,6.51.10,1. Fixed AGI issue,1729
 ,,2. Updated the Devkit from 6.51.06 to 6.51.10,

--- a/zwave/Enbrighten-GE/ZW4201/14284 - Plug-in Outdoor Smart Switch, 500S/14284_Revision_History.csv
+++ b/zwave/Enbrighten-GE/ZW4201/14284 - Plug-in Outdoor Smart Switch, 500S/14284_Revision_History.csv
@@ -3,6 +3,6 @@ Manufacturer ID,0x0063,,
 Product Type ID,0x4f50,,
 Product ID,0x3032,,
 VERSION,Z-Wave Devkit,Changes,Date Code
-5.2,6.51.06,1. Original Release Firmware,1651
+5.20,6.51.06,1. Original Release Firmware,1651
 ,,OTA file will not be released for this version due to lack of support for Adesto flash in newer hardware,
 5.21,6.51.10,1. Updated the devkit from 6.51.06 to 6.51.10,1737

--- a/zwave/Enbrighten-GE/ZW6301/32563 - Hinge Pin Door Sensor, 500S/32563_Revision_History.csv
+++ b/zwave/Enbrighten-GE/ZW6301/32563 - Hinge Pin Door Sensor, 500S/32563_Revision_History.csv
@@ -4,4 +4,4 @@ Product Type ID,0x4953,,
 Product ID,0x3032,,
 VERSION,Z-Wave Devkit,Changes,Date Code
 1.35,6.51.07,1. Original Release Firmware,1636
-5.21,6.51.07,1. Modified the version number,1651
+5.20,6.51.07,1. Modified the version number,1651

--- a/zwave/Jasco/ZW3105/28170 - Plug-in 2-Outlet Smart Dimmer, 1 Controlled, 500S/28170_Revision_History.csv
+++ b/zwave/Jasco/ZW3105/28170 - Plug-in 2-Outlet Smart Dimmer, 1 Controlled, 500S/28170_Revision_History.csv
@@ -4,6 +4,6 @@ Product Type ID,0x5044,,
 Product ID,0x3039,,
 VERSION,Z-Wave Devkit,Changes,Date Code
 5.02,6.51.06,1. Original Release Firmware,1537
-5.2,6.51.08,1. Updated Switch Multilevel command class to latest version,1705
+5.20,6.51.08,1. Updated Switch Multilevel command class to latest version,1705
 ,,2. Added parameter 6,
 ,,3. Modify the default setting for LED indication,

--- a/zwave/Jasco/ZW4003/14319 - In-Wall Smart Toggle Switch, 500S/14319_Revision_History.csv
+++ b/zwave/Jasco/ZW4003/14319 - In-Wall Smart Toggle Switch, 500S/14319_Revision_History.csv
@@ -3,7 +3,7 @@ Manufacturer ID,0x0063,,
 Product Type ID,0x4952,,
 Product ID,0x3131,,
 VERSION,Z-Wave Devkit,Changes,Date Code
-5.2,6.51.06,1. Original Release Firmware,1648
+5.20,6.51.06,1. Original Release Firmware,1648
 ,,OTA file will not be released for this version due to lack of support for Adesto flash in newer hardware,
 5.21,6.51.10,1. Updated the devkit from 6.51.06 to 6.51.10,1749
 5.22,6.51.10,1. Added parameter 19 for alternate exclusion,1902

--- a/zwave/Jasco/ZW4005/14318 - In-Wall Smart Paddle Switch, 500S/14318_Revision_History.csv
+++ b/zwave/Jasco/ZW4005/14318 - In-Wall Smart Paddle Switch, 500S/14318_Revision_History.csv
@@ -4,7 +4,7 @@ Product Type ID,0x4952,,
 Product ID,0x3130,,
 VERSION,Z-Wave Devkit,Changes,Date Code
 5.07,6.51.06,1. Original Release Firmware,1535
-5.2,6.51.06,1. Modify the default setting for LED indication,1648
+5.20,6.51.06,1. Modify the default setting for LED indication,1648
 ,,2. Fixed an issue where node info was automatically sent in NWI mode,
 ,,"3. Fixed the reset and exclusion failure for the host device if associated with G1, G2 and G3",
 5.22,6.51.10,1. Fixed AGI issue,1749

--- a/zwave/Jasco/ZW4201/14311 - Plug-in Outdoor Smart Switch, 500S/14311_Revision_History.csv
+++ b/zwave/Jasco/ZW4201/14311 - Plug-in Outdoor Smart Switch, 500S/14311_Revision_History.csv
@@ -3,4 +3,4 @@ Manufacturer ID,0x0063,,
 Product Type ID,0x4f50,,
 Product ID,0x3033,,
 VERSION,Z-Wave Devkit,Changes,Date Code
-5.2,6.51.06,1. Original Release Firmware,1725
+5.20,6.51.06,1. Original Release Firmware,1725


### PR DESCRIPTION
These versions did not have a matching directory, but the fixed ones do.